### PR TITLE
feat(iam): customize wallet signing message when verifying stamps

### DIFF
--- a/iam/src/utils/providers.ts
+++ b/iam/src/utils/providers.ts
@@ -2,9 +2,6 @@
 import type { Provider } from "../types";
 import type { RequestPayload, ChallengePayload, VerifiedPayload } from "@dpopp/types";
 
-// ---- Return randomBytes as a challenge to test that the user has control of a provided address
-import crypto from "crypto";
-
 // Collate all Providers to abstract verify logic
 export class Providers {
   // collect providers against instance
@@ -34,7 +31,7 @@ export class Providers {
         record: {
           address: payload.address,
           type: payload.type,
-          challenge: crypto.randomBytes(32).toString("hex"),
+          challenge: `I commit that this stamp is my unique and only ${payload.type} verification for Passport.`,
         },
       };
     } else {


### PR DESCRIPTION
message: "I commit that this stamp is my unique and only <provider name> verification for Passport."

[resolves #166]

Examples:
![Metamask signature request for Google stamp verification](https://user-images.githubusercontent.com/62616399/172645879-8d6a9f6d-4092-4330-bb6c-b57a9fd2b5f1.png)
![Metamask signature request for Twitter stamp verification](https://user-images.githubusercontent.com/62616399/172645886-d3e86d99-d6ac-4297-ad89-367005c3f002.png)
