### PR TITLE
fix: only creates a new passport if we get an empty response from ceramic

### DIFF
--- a/app/__tests__/components/Card.test.tsx
+++ b/app/__tests__/components/Card.test.tsx
@@ -42,6 +42,11 @@ describe("when the passport is loading", () => {
 
 describe("when the user is not verified", () => {
   beforeEach(() => {
+    mockUserContext.passport = {
+      expiryDate: new Date(),
+      issuanceDate: new Date(),
+      stamps: []
+    };
     mockUserContext.isLoadingPassport = false;
     // set up Some provider without a VC
     cardProps = {
@@ -90,6 +95,11 @@ describe("when the user is not verified", () => {
 
 describe("when the user is verified", () => {
   beforeEach(() => {
+    mockUserContext.passport = {
+      expiryDate: new Date(),
+      issuanceDate: new Date(),
+      stamps: []
+    };
     mockUserContext.isLoadingPassport = false;
     // set up Some provider with a mocked VC (verified)
     cardProps = {

--- a/app/__tests__/components/Card.test.tsx
+++ b/app/__tests__/components/Card.test.tsx
@@ -45,7 +45,7 @@ describe("when the user is not verified", () => {
     mockUserContext.passport = {
       expiryDate: new Date(),
       issuanceDate: new Date(),
-      stamps: []
+      stamps: [],
     };
     mockUserContext.isLoadingPassport = false;
     // set up Some provider without a VC
@@ -98,7 +98,7 @@ describe("when the user is verified", () => {
     mockUserContext.passport = {
       expiryDate: new Date(),
       issuanceDate: new Date(),
-      stamps: []
+      stamps: [],
     };
     mockUserContext.isLoadingPassport = false;
     // set up Some provider with a mocked VC (verified)

--- a/app/__tests__/components/ProviderCards/BrightidCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/BrightidCard.test.tsx
@@ -20,7 +20,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: "mockUserDid",
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Brightid: {

--- a/app/__tests__/components/ProviderCards/EnsCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/EnsCard.test.tsx
@@ -20,7 +20,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Ens: {

--- a/app/__tests__/components/ProviderCards/FacebookCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/FacebookCard.test.tsx
@@ -15,7 +15,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Facebook: {

--- a/app/__tests__/components/ProviderCards/GoogleCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/GoogleCard.test.tsx
@@ -15,7 +15,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Google: {

--- a/app/__tests__/components/ProviderCards/PoapCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/PoapCard.test.tsx
@@ -20,7 +20,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     POAP: {

--- a/app/__tests__/components/ProviderCards/PohCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/PohCard.test.tsx
@@ -20,7 +20,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Poh: {

--- a/app/__tests__/components/ProviderCards/TwitterCard.test.tsx
+++ b/app/__tests__/components/ProviderCards/TwitterCard.test.tsx
@@ -15,7 +15,11 @@ const handleAddStamp = jest.fn().mockResolvedValue(undefined);
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Twitter: {

--- a/app/__tests__/pages/Dashboard.test.tsx
+++ b/app/__tests__/pages/Dashboard.test.tsx
@@ -94,9 +94,10 @@ describe("when user has no passport", () => {
 
     expect(screen.getByTestId("loading-spinner-passport")).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(mockCreatePassport).toBeCalledTimes(1);
-    });
+    // This call has been moved to userContext::fetchPassport
+    // await waitFor(() => {
+    //   expect(mockCreatePassport).toBeCalledTimes(1);
+    // });
   });
 });
 

--- a/app/__tests__/pages/Dashboard.test.tsx
+++ b/app/__tests__/pages/Dashboard.test.tsx
@@ -21,7 +21,11 @@ const handleAddStamp = jest.fn();
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: true,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Google: {
@@ -76,7 +80,7 @@ beforeEach(() => {
 describe("when user has no passport", () => {
   const mockUserContextWithNoPassport: UserContextState = {
     ...mockUserContext,
-    passport: undefined,
+    passport: false,
   };
 
   it("should display a loading spinner, and call create passport", async () => {

--- a/app/__tests__/pages/Home.test.tsx
+++ b/app/__tests__/pages/Home.test.tsx
@@ -14,7 +14,11 @@ const handleAddStamp = jest.fn();
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: false,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Google: {

--- a/app/__tests__/pages/index.test.tsx
+++ b/app/__tests__/pages/index.test.tsx
@@ -11,7 +11,11 @@ const handleAddStamp = jest.fn();
 const mockUserContext: UserContextState = {
   userDid: undefined,
   loggedIn: false,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  },
   isLoadingPassport: false,
   allProvidersState: {
     Google: {

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -28,7 +28,7 @@ export const Card = ({
   issueCredentialWidget,
   isLoading = false,
 }: CardProps): JSX.Element => {
-  const { isLoadingPassport } = useContext(UserContext);
+  const { passport, isLoadingPassport } = useContext(UserContext);
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <div className="w-full p-4 md:w-1/2 xl:w-1/4">
@@ -81,7 +81,8 @@ export const Card = ({
           <h1 className="title-font mb-3 text-lg font-medium text-gray-900">{providerSpec.name}</h1>
           <p className="pleading-relaxed">{providerSpec.description}</p>
         </div>
-        {isLoadingPassport ? (
+        {/* TODO: change this to passport===false and introduce an offline save state when passport===undefined */}
+        {!passport || isLoadingPassport ? (
           <span className="flex w-full items-center justify-center border-t-2 p-3 text-gray-900">
             <span>
               <Spinner

--- a/app/context/userContext.tsx
+++ b/app/context/userContext.tsx
@@ -65,7 +65,7 @@ const startingAllProvidersState: AllProvidersState = {
 
 export interface UserContextState {
   loggedIn: boolean;
-  passport: Passport | undefined;
+  passport: Passport | undefined | false;
   isLoadingPassport: boolean;
   allProvidersState: AllProvidersState;
   handleCreatePassport: () => Promise<void>;
@@ -79,7 +79,11 @@ export interface UserContextState {
 }
 const startingState: UserContextState = {
   loggedIn: false,
-  passport: undefined,
+  passport: {
+    issuanceDate: new Date(),
+    expiryDate: new Date(),
+    stamps: [],
+  } as Passport,
   isLoadingPassport: true,
   allProvidersState: startingAllProvidersState,
   handleCreatePassport: async () => {},

--- a/app/context/userContext.tsx
+++ b/app/context/userContext.tsx
@@ -284,7 +284,7 @@ export const UserContextProvider = ({ children }: { children: any }) => {
       handleCreatePassport();
     } else {
       // something is wrong with Ceramic...
-      console.warn("Ceramic connection failed");
+      datadogLogs.logger.info("Ceramic connection failed", { address });
       // no ceramic...
       setAddress(undefined);
       handleConnection();

--- a/app/context/userContext.tsx
+++ b/app/context/userContext.tsx
@@ -288,7 +288,7 @@ export const UserContextProvider = ({ children }: { children: any }) => {
       handleCreatePassport();
     } else {
       // something is wrong with Ceramic...
-      datadogLogs.logger.info("Ceramic connection failed", { address });
+      datadogRum.addError("Ceramic connection failed", { address });
       // no ceramic...
       setAddress(undefined);
       handleConnection();

--- a/app/pages/Dashboard.tsx
+++ b/app/pages/Dashboard.tsx
@@ -15,7 +15,7 @@ import { UserContext } from "../context/userContext";
 import { useViewerConnection } from "@self.id/framework";
 
 export default function Dashboard() {
-  const { passport, isLoadingPassport, handleCreatePassport, wallet } = useContext(UserContext);
+  const { passport, wallet } = useContext(UserContext);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -29,12 +29,6 @@ export default function Dashboard() {
       navigate("/");
     }
   }, [wallet]);
-
-  useEffect(() => {
-    if (!passport && !isLoadingPassport) {
-      handleCreatePassport();
-    }
-  }, [passport, isLoadingPassport]);
 
   return (
     <>

--- a/database-client/integration-tests/ceramicDatabaseTest.ts
+++ b/database-client/integration-tests/ceramicDatabaseTest.ts
@@ -51,10 +51,10 @@ describe("when there is no passport for the given did", () => {
     expect(storedPassport["stamps"]).toEqual([]);
   });
 
-  it("getPassport returns undefined", async () => {
+  it("getPassport returns false", async () => {
     const actualPassport = await ceramicDatabase.getPassport();
 
-    expect(actualPassport).toEqual(undefined);
+    expect(actualPassport).toEqual(false);
   });
 });
 

--- a/database-client/integration-tests/ceramicDatabaseTest.ts
+++ b/database-client/integration-tests/ceramicDatabaseTest.ts
@@ -76,7 +76,7 @@ describe("when there is an existing passport without stamps for the given did", 
   });
 
   it("getPassport retrieves the passport from ceramic", async () => {
-    const actualPassport = await ceramicDatabase.getPassport();
+    const actualPassport = await ceramicDatabase.getPassport() as Passport;
 
     expect(actualPassport).toBeDefined();
     expect(actualPassport).toEqual(existingPassport);
@@ -195,7 +195,7 @@ describe("when there is an existing passport with stamps for the given did", () 
   });
 
   it("getPassport retrieves the passport and stamps from ceramic", async () => {
-    const actualPassport = await ceramicDatabase.getPassport();
+    const actualPassport = await ceramicDatabase.getPassport() as Passport;
 
     const formattedDate = new Date(actualPassport["issuanceDate"]);
     const todaysDate = new Date();

--- a/database-client/src/ceramicClient.ts
+++ b/database-client/src/ceramicClient.ts
@@ -74,11 +74,11 @@ export class CeramicDatabase implements DataStorageBase {
     const stream = await this.store.set("Passport", { ...newPassport });
     return stream.toUrl();
   }
-  async getPassport(): Promise<Passport | undefined> {
+  async getPassport(): Promise<Passport | undefined | false> {
     try {
       const passport = await this.store.get("Passport");
       console.info(`loaded passport for did ${this.did} => ${JSON.stringify(passport)}`);
-      if (!passport) return undefined;
+      if (!passport) return false;
       // `stamps` is stored as ceramic URLs - must load actual VC data from URL
       const stampsToLoad =
         passport?.stamps.map(async (_stamp) => {

--- a/database-client/src/types.ts
+++ b/database-client/src/types.ts
@@ -6,6 +6,6 @@ import { Passport, Stamp, DID } from "@dpopp/types";
 //  calling createPassport, getPassport, addStamp
 export abstract class DataStorageBase {
   abstract createPassport(): Promise<DID>;
-  abstract getPassport(): Promise<Passport | undefined>;
+  abstract getPassport(): Promise<Passport | undefined | false>;
   abstract addStamp(stamp: Stamp): Promise<void>;
 }


### PR DESCRIPTION
This PR ensures that `createPassport` is only called if we get a response from ceramic and that response is empty.

--

related to #196