### PR TITLE
fix: ensures addresses fed to Ceramic are lowercase

### DIFF
--- a/app/context/userContext.tsx
+++ b/app/context/userContext.tsx
@@ -185,8 +185,8 @@ export const UserContextProvider = ({ children }: { children: any }) => {
         window.localStorage.setItem("connectedWallets", JSON.stringify([wallet.label]));
         // attempt to connect to ceramic (if it passes or fails always set loggingIn=false)
         try {
-          // connect to ceramic
-          await ceramicConnect(new EthereumAuthProvider(wallet.provider, wallet.accounts[0].address));
+          // connect to ceramic (deliberately connect with a lowercase DID to match reader)
+          await ceramicConnect(new EthereumAuthProvider(wallet.provider, wallet.accounts[0].address.toLowerCase()));
         } finally {
           // mark that this login attempt is complete
           setLoggingIn(false);

--- a/app/pages/Dashboard.tsx
+++ b/app/pages/Dashboard.tsx
@@ -46,7 +46,8 @@ export default function Dashboard() {
   // Allow user to retry Ceramic connection if failed
   const retryConnection = () => {
     if (isLoadingPassport == undefined && wallet) {
-      ceramicConnect(new EthereumAuthProvider(wallet.provider, wallet.accounts[0].address));
+      // connect to ceramic (deliberately connect with a lowercase DID to match reader)
+      ceramicConnect(new EthereumAuthProvider(wallet.provider, wallet.accounts[0].address.toLowerCase()));
       onRetryModalClose();
     }
   };


### PR DESCRIPTION
Ensures that we feed a lowercase Address in to Ceramic so that the resultant DID is lowercase - this will ensure the DID we read from is always the same as the DID we write to.

Fixes: #252