### PR TITLE
refactor(iam): use different http status codes for different iam error response types

### DIFF
--- a/iam/__tests__/index.test.ts
+++ b/iam/__tests__/index.test.ts
@@ -47,7 +47,38 @@ describe("POST /challenge", function () {
       .expect("Content-Type", /json/);
 
     // expect the mocked credential to be returned and contain the expectedId
-    expect((response.body as ErrorResponseBody).error).toEqual("Unable to verify payload");
+    expect((response.body as ErrorResponseBody).error).toEqual("Missing address from challenge request body");
+  });
+
+  it("handles missing type from the challenge request body", async () => {
+    // as each signature is unique, each request results in unique output
+    const payload = {
+      address: "0x0",
+    };
+
+    // create a req against the express app
+    const response = await request(app)
+      .post("/api/v0.0.0/challenge")
+      .send({ payload })
+      .set("Accept", "application/json")
+      .expect(400)
+      .expect("Content-Type", /json/);
+
+    // expect the mocked credential to be returned and contain the expectedId
+    expect((response.body as ErrorResponseBody).error).toEqual("Missing type from challenge request body");
+  });
+
+  it("handles malformed payload from the challenge request body", async () => {
+    // as each signature is unique, each request results in unique output
+    const payload = "bad :(";
+
+    // create a req against the express app
+    const response = await request(app)
+      .post("/api/v0.0.0/challenge")
+      .send({ payload })
+      .set("Accept", "application/json")
+      .expect(400)
+      .expect("Content-Type", /json/);
   });
 });
 
@@ -119,7 +150,7 @@ describe("POST /verify", function () {
       .post("/api/v0.0.0/verify")
       .send({ challenge, payload })
       .set("Accept", "application/json")
-      .expect(400)
+      .expect(401)
       .expect("Content-Type", /json/);
 
     expect((response.body as ErrorResponseBody).error).toEqual("Unable to verify payload");
@@ -151,7 +182,7 @@ describe("POST /verify", function () {
       .post("/api/v0.0.0/verify")
       .send({ challenge, payload })
       .set("Accept", "application/json")
-      .expect(400)
+      .expect(401)
       .expect("Content-Type", /json/);
 
     expect((response.body as ErrorResponseBody).error).toEqual("Unable to verify payload");
@@ -184,7 +215,7 @@ describe("POST /verify", function () {
       .post("/api/v0.0.0/verify")
       .send({ challenge, payload })
       .set("Accept", "application/json")
-      .expect(400)
+      .expect(403)
       .expect("Content-Type", /json/);
 
     expect((response.body as ErrorResponseBody).error).toEqual("Unable to verify proofs");
@@ -219,7 +250,7 @@ describe("POST /verify", function () {
       .post("/api/v0.0.0/verify")
       .send({ challenge, payload })
       .set("Accept", "application/json")
-      .expect(400)
+      .expect(500)
       .expect("Content-Type", /json/);
 
     expect((response.body as ErrorResponseBody).error).toEqual("Unable to verify payload");

--- a/iam/tsconfig.json
+++ b/iam/tsconfig.json
@@ -14,5 +14,5 @@
       "*": ["../node_modules/*", "node_modules/*"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "__tests__"]
 }


### PR DESCRIPTION
refactor(iam): use different http status codes for different iam error response types

previously all error responses returned 400 Bad Request codes. this change returns different codes
(401, 403, 500) for certain situations. also adds `__tests__` to iam tsconfig to resolve
esModuleInterop warning on `supertest` library usage

[#70]