### PR TITLE
test(database-client): assert equality on method results, instead of method reference

### DIFF
--- a/database-client/integration-tests/ceramicDatabaseTest.ts
+++ b/database-client/integration-tests/ceramicDatabaseTest.ts
@@ -45,9 +45,9 @@ describe("when there is no passport for the given did", () => {
     const formattedDate = new Date(storedPassport["issuanceDate"]);
     const todaysDate = new Date();
 
-    expect(formattedDate.getDay).toEqual(todaysDate.getDay);
-    expect(formattedDate.getMonth).toEqual(todaysDate.getMonth);
-    expect(formattedDate.getFullYear).toEqual(todaysDate.getFullYear);
+    expect(formattedDate.getDay()).toEqual(todaysDate.getDay());
+    expect(formattedDate.getMonth()).toEqual(todaysDate.getMonth());
+    expect(formattedDate.getFullYear()).toEqual(todaysDate.getFullYear());
     expect(storedPassport["stamps"]).toEqual([]);
   });
 
@@ -198,12 +198,11 @@ describe("when there is an existing passport with stamps for the given did", () 
     const actualPassport = await ceramicDatabase.getPassport() as Passport;
 
     const formattedDate = new Date(actualPassport["issuanceDate"]);
-    const todaysDate = new Date();
 
     expect(actualPassport).toBeDefined();
-    expect(formattedDate.getDay).toEqual(todaysDate.getDay);
-    expect(formattedDate.getMonth).toEqual(todaysDate.getMonth);
-    expect(formattedDate.getFullYear).toEqual(todaysDate.getFullYear);
+    expect(formattedDate.getDay()).toEqual(existingPassport.issuanceDate.getDay());
+    expect(formattedDate.getMonth()).toEqual(existingPassport.issuanceDate.getMonth());
+    expect(formattedDate.getFullYear()).toEqual(existingPassport.issuanceDate.getFullYear());
     expect(actualPassport.stamps[0]).toEqual(ensStampFixture);
   });
 


### PR DESCRIPTION
test(database-client): assert equality on method results, instead of method reference

also fix `getPassport retrieves the passport and stamps from ceramic` test to assert against
existingPassport date instead of today's date